### PR TITLE
remove active class instead of entire class attribute

### DIFF
--- a/src/swiffy-slider.js
+++ b/src/swiffy-slider.js
@@ -119,8 +119,9 @@ const swiffyslider = function() {
             for (const scrollIndicatorContainers of sliderElement.querySelectorAll(".slider-indicators")) {
                 const scrollIndicators = scrollIndicatorContainers.children;
                 const activeIndicator = Math.round((scrollIndicators.length - 1) * percentSlide);
-                for (const element of scrollIndicators)
-                    element.removeAttribute("class");
+                for (const element of scrollIndicators) {
+                    element.classList.remove('active');
+                }
                 scrollIndicators[activeIndicator].classList.add("active");
             }
         }


### PR DESCRIPTION
Use `classList.remove` to strip `active` class so other classes aren't removed along with it.