### PR TITLE
Ensure positive indicator index on rtl

### DIFF
--- a/src/swiffy-slider.js
+++ b/src/swiffy-slider.js
@@ -119,7 +119,7 @@ const swiffyslider = function() {
             const percentSlide = (container.scrollLeft / slidingAreaWidth);
             for (let scrollIndicatorContainers of sliderElement.querySelectorAll(".slider-indicators")) {
                 let scrollIndicators = scrollIndicatorContainers.children;
-                let activeIndicator = Math.round((scrollIndicators.length - 1) * percentSlide);
+                let activeIndicator = Math.abs(Math.round((scrollIndicators.length - 1) * percentSlide));
                 for (let element of scrollIndicators)
                     element.classList.remove("active");
                 scrollIndicators[activeIndicator].classList.add("active");


### PR DESCRIPTION
When in RTL mode, the activeIndicator comes out as a negative value. Ensure it is positive to not  cause error