### PR TITLE
Avoid stretched images if image doesn't exactly fit

### DIFF
--- a/src/swiffy-slider.css
+++ b/src/swiffy-slider.css
@@ -70,8 +70,8 @@
     /*The slides*/
     scroll-snap-align: var(--swiffy-slider-snap-align);
     position: relative;
-    width: 100%;
-    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
 }
 
 .slider-item-helper .slider-container>* {


### PR DESCRIPTION
When using `width` and `height`:
![swiffyslider-streched](https://user-images.githubusercontent.com/8647429/153152229-16028c77-0beb-4378-b184-48d3f01c4231.png)

After using `max-width` and `max-height`:
![swiffyslider-ratio](https://user-images.githubusercontent.com/8647429/153152242-201e2401-e0c0-44d6-bc84-dd28b299a567.png)
