### PR TITLE
Change exports to include src css

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,14 @@
         "version_short": "1.4"
     },
     "type": "module",
-    "exports": "./src/swiffy-slider.esm.js",
+    "exports": {
+        ".": {
+            "import": "./src/swiffy-slider.esm.js"
+        },
+        "./src/swiffy-slider.css": {
+            "import": "./src/swiffy-slider.css"
+        }
+    },
     "style": "./src/swiffy-slider.css",
     "browser": "./dist/js/swiffy-slider.min.js",
     "files": [


### PR DESCRIPTION
Include src css in exports collection to allow using 
`import css from "swiffy-slider/src/swiffy-slider.css"`